### PR TITLE
Allow "symfony/yaml" v6 for latest Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "phpstan/phpstan": "^1.8",
-    "symfony/yaml": "^5.4",
+    "symfony/yaml": "^5.4 || ^6.0",
     "symfony/polyfill-php80": "^v1.27.0"
   },
   "require-dev": {


### PR DESCRIPTION
Hey guys! Great module! We are planing to use it in our Laravel project.

The only problem is we also using `Larastan` PHPStan extension (v2.2.9), which uses `orchestra/testbench` (v7.15.0), and all other packages allow v5 and v6 of `symfony/yaml`, but `testbench` is locked to "^6.0.9".

I have tested you package with yaml v6, and it works.

We of course just made a fork of it for or usage, but it would be great if you allow for yaml v6 also.